### PR TITLE
nil interface check fix

### DIFF
--- a/table_types.go
+++ b/table_types.go
@@ -14,6 +14,10 @@ func (p *Printer) makeTable(value interface{}) (*table, error) {
 	if value == nil {
 		return nil, ErrNoData
 	}
+	reflectedValueType := reflect.TypeOf(value)
+	if reflect.ValueOf(value) == reflect.Zero(reflectedValueType) {
+		return nil, ErrNoData
+	}
 
 	// See if we have an easily stringable interface:
 	if stringable, ok := value.(stringable); ok {
@@ -21,7 +25,7 @@ func (p *Printer) makeTable(value interface{}) (*table, error) {
 	}
 
 	// Take a different approach depending on the type of data that was provided:
-	switch reflect.TypeOf(value).Kind() {
+	switch reflectedValueType.Kind() {
 
 	// Maps get turned into a single-row table:
 	case reflect.Map:


### PR DESCRIPTION

Adding :

```
        reflectedValueType := reflect.TypeOf(value)
        if reflect.ValueOf(value) == reflect.Zero(reflectedValueType) {
                return nil, ErrNoData
        }
```

To fix a problem where makeTable throws a nil pointer exception, when it gets a nil interface passed as a value:

```
panic: reflect: call of reflect.Value.Interface on zero Value

goroutine 1 [running]:
reflect.valueInterface(0x0, 0x0, 0x0, 0x1, 0x0, 0x0)
/usr/local/Cellar/go/1.12.5/libexec/src/reflect/value.go:984 +0x1a1
reflect.Value.Interface(...)
/usr/local/Cellar/go/1.12.5/libexec/src/reflect/value.go:979
github.com/chrusty/go-tableprinter.(*Printer).makeTable(0xc000172870, 0x1450840, 0x0, 0x0, 0x0, 0x0)
/Users/hax0r/go/pkg/mod/github.com/chrusty/go-tableprinter@v0.0.0-20190528113659-0de6c8f09400/table_types.go:32 +0x160
github.com/chrusty/go-tableprinter.(*Printer).Marshal(0xc000172870, 0x1450840, 0x0, 0x13d30a8, 0xc000424000, 0xc000173800, 0x0, 0x0)
/Users/hax0r/go/pkg/mod/github.com/chrusty/go-tableprinter@v0.0.0-20190528113659-0de6c8f09400/printer.go:77 +0x43
github.com/chrusty/go-tableprinter.(*Printer).Print(0xc000172870, 0x1450840, 0x0, 0x0, 0x0)
/Users/hax0r/go/pkg/mod/github.com/chrusty/go-tableprinter@v0.0.0-20190528113659-0de6c8f09400/printer.go:60 +0x43

```

The added code fixes the issue. 
also changed :
```
	switch reflect.TypeOf(value).Kind() {
```

to:
```
switch reflectedValueType.Kind() {
```
Since I'm declaring an object:
```
reflectedValueType := reflect.TypeOf(value)
```
To avoid wasting resources, by calling reflect.TypeOf(value) twice.
